### PR TITLE
Allow DebugKit to bypass auth

### DIFF
--- a/config/permissions.php
+++ b/config/permissions.php
@@ -138,6 +138,13 @@ return [
             'controller' => 'Articles',
             'action' => ['edit'],
             'allowed' => new \CakeDC\Auth\Rbac\Rules\Owner()
-        ]
+        ],
+        [
+            'role' => '*',
+            'plugin' => 'DebugKit',
+            'controller' => ['Requests', 'Panels'],
+            'action' => '*',
+            'bypassAuth' => true,
+        ],
     ]
 ];


### PR DESCRIPTION
Otherwise there is an endless loop of debug toolbar requests: https://i.vgy.me/qbWtua.mp4

DebugKit is enabled automatically during development if the SQLite extension is available, and if debug mode is on.

This may not be the ideal way to do it, though. Perhaps there should be some logic elsewhere that determines if DebugKit is enabled...